### PR TITLE
Show coverage for selected cluster.

### DIFF
--- a/AGSClusterLayer/AGSCluster.h
+++ b/AGSClusterLayer/AGSCluster.h
@@ -26,11 +26,13 @@
 //Coverage geometry of the cluster
 @property (nonatomic, readonly) AGSGeometry *coverage;
 
+//The coverage graphic of the cluster
+@property (nonatomic, readonly) AGSGraphic *coverageGraphic;
+
 //Envelope of the coverage
 @property (nonatomic, readonly) AGSEnvelope *envelope;
 
-//The coverage graphic of the cluster
-@property (nonatomic, readonly) AGSGraphic *coverageGraphic;
+@property (nonatomic, assign) BOOL showCoverage;
 
 //Initializes and returns an AGSCluster object for the given point
 +(AGSCluster *)clusterForPoint:(AGSPoint *)point;

--- a/AGSClusterLayer/AGSCluster.m
+++ b/AGSClusterLayer/AGSCluster.m
@@ -127,6 +127,7 @@
 -(AGSGraphic *)coverageGraphic {
     if (!_coverageGraphic) {
         _coverageGraphic = [AGSGraphic graphicWithGeometry:self.coverage symbol:nil attributes:nil];
+        objc_setAssociatedObject(_coverageGraphic, kClusterPayloadKey, self, OBJC_ASSOCIATION_ASSIGN);
     }
     return _coverageGraphic;
 }

--- a/AGSClusterLayer/AGSClusterLayerRenderer.m
+++ b/AGSClusterLayer/AGSClusterLayerRenderer.m
@@ -9,6 +9,7 @@
 #import "AGSClusterLayerRenderer.h"
 #import "AGSCluster.h"
 #import "Common_int.h"
+#import "AGSGraphic+AGSClustering.h"
 #import <objc/runtime.h>
 
 @interface AGSClusterLayerRenderer ()
@@ -93,12 +94,12 @@
         return self.clusterGenBlock((AGSCluster *)feature);
     }
     
-    AGSCluster *cluster = objc_getAssociatedObject(feature, kClusterPayloadKey);
+    AGSCluster *cluster = ((AGSGraphic *)feature).owningCluster;
     if (cluster != nil &&
         [feature.geometry isKindOfClass:[AGSPolygon class]]) {
-        return self.coverageGenBlock((AGSCluster *)feature);
+        return self.coverageGenBlock(cluster);
     }
-        
+
     return [self.originalRenderer symbolForFeature:feature timeExtent:timeExtent];
 }
 @end

--- a/AGSClusterLayer/AGSGraphic+AGSClustering.h
+++ b/AGSClusterLayer/AGSGraphic+AGSClustering.h
@@ -7,11 +7,14 @@
 //
 
 #import <ArcGIS/ArcGIS.h>
+@class AGSCluster;
 
 @interface AGSGraphic (AGSClustering)
 
 //Determines whether the graphic is a cluster
 @property (nonatomic, readonly) BOOL isCluster;
+@property (nonatomic, readonly) BOOL isClusterCoverage;
+@property (nonatomic, readonly) AGSCluster *owningCluster;
 
 -(id)clusterItemKey;
 @end

--- a/AGSClusterLayer/AGSGraphic+AGSClustering.m
+++ b/AGSClusterLayer/AGSGraphic+AGSClustering.m
@@ -9,12 +9,19 @@
 #import "AGSGraphic+AGSClustering.h"
 #import <objc/runtime.h>
 #import "AGSCluster.h"
+#import "Common_int.h"
 
 @implementation AGSGraphic (AGSClustering)
-
-
 -(BOOL)isCluster {
     return NO;
+}
+
+-(BOOL)isClusterCoverage {
+    return self.owningCluster != nil;
+}
+
+-(AGSCluster *)owningCluster {
+    return objc_getAssociatedObject(self, kClusterPayloadKey);
 }
 
 -(id)clusterItemKey {

--- a/Sample/Source/AGSSampleViewController.m
+++ b/Sample/Source/AGSSampleViewController.m
@@ -33,16 +33,23 @@
     [self.mapView addMapLayer:[AGSTiledMapServiceLayer tiledMapServiceLayerWithURL:[NSURL URLWithString:kBasemap]]];
     
     AGSFeatureLayer *featureLayer = [AGSFeatureLayer featureServiceLayerWithURL:[NSURL URLWithString:kFeatureLayerURL] mode:AGSFeatureLayerModeOnDemand];
-    [self.mapView addMapLayer:featureLayer];
     
 
-    
+    /// *******************************
+    /// Cluster Layer Setup
+
+    // Must add the source layer to connect it to its end point.
+    [self.mapView addMapLayer:featureLayer];
+
+    // Now wrap it in an AGSClusterLayer. The original FeatureLayer will be hidden in the map.
     self.clusterLayer = [AGSClusterLayer clusterLayerForFeatureLayer:featureLayer];
     [self.mapView addMapLayer:self.clusterLayer];
 
     // Cluster layer config
     self.clusterLayer.showsClusterCoverages = self.coverageSwitch.on;
     self.clusterLayer.minScaleForClustering = 15000;
+    
+    /// *******************************
 
     
     


### PR DESCRIPTION
Add some stuff to the AGSGraphic category to identify that a coverage graphic is associated with a cluster. Add some logic to the AGSClusterLayer to show the coverage's graphic when it is tapped in the map view.
